### PR TITLE
Use yed if not yEd command available

### DIFF
--- a/editmodel.sh
+++ b/editmodel.sh
@@ -14,4 +14,8 @@ else
     exit 1;
 fi
 
-yEd $FILE3
+if ! type yEd &> /dev/null; then
+  yed $FILE3
+else
+  yEd $FILE3
+fi


### PR DESCRIPTION
I installed `yEd` in Manjaro using the available package in the AUR repository.

```
yed  1:3.23.2-1 [Instalados]                                                                         AUR
    Very powerful graph editor written in java
```

This package doesn't set a `yEd` command, it sets `yed` instead.

This contribution checks if `yEd` is available, if it is available, it uses it. If it isn't available, it uses `yed`.